### PR TITLE
Fix event listener on remove link

### DIFF
--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -39,9 +39,12 @@ window.onload = () => {
       let newRow = dataset.prototype;
       container.insertAdjacentHTML("beforeend",       newRow.replace(/__name__/g, index));
       container.dataset.index = parseInt(container.dataset.index) + 1;
-      container.querySelector("a.remove-form-field").onclick = (e) => {
-        removeElement(e);
-      }
+      Array.from(container.querySelectorAll("a.remove-form-field"))
+      .forEach(el => {
+        el.onclick = (e) => {
+          removeElement(e);
+        }
+      })
     }
   });
 }


### PR DESCRIPTION
This is really a quick fix, you may absolutely find better than just re-applying the remove event to all the array tree. It works arround well though.